### PR TITLE
Remove non-conformant filter test

### DIFF
--- a/test/expr/filter.yml
+++ b/test/expr/filter.yml
@@ -206,11 +206,6 @@ tests:
     [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v in [{"v":1},{"v":2},{"v":3}][v>=2][].v][].v][].v][].v][].v][].v][].v][].v][].v
   result: [2, 3]
 
-- name: Optional pipe
-  query: |
-    *[true]|[true]|[true]|[true]|[true]|[true]|[true]|[true]|[true]|[true][]._id
-  result: ["a", "b", "c", "d", "e", "id"]
-
 - name: "Null parent scoping"
   query: |
     *[_id == ^.other._ref][]


### PR DESCRIPTION
Removes test for `*[true]|[true]|[true]|[true]|[true]|[true]|[true]|[true]|[true]|[true][]._id`, which does not conform to spec.