### PR TITLE
Generate additional test cases automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ tests:
 
 ### Variables
 
-Queries can use the syntax `${name}` for referring to variables.
+Queries can use the syntax `~name~` for referring to variables.
 Together with test inheritance this can be used to succinctly test many different cases.
 
 ```yaml
@@ -141,7 +141,7 @@ documents:
 tests:
   - name: "Filtering"
     query: |
-      count(*[${filter}])
+      count(*[~filter~])
     tests:
       - result: 1
         variables:
@@ -150,6 +150,35 @@ tests:
         variables:
           filter: '_id >= "b"'
 ```
+
+### Automatic test generation based on variables
+
+To increase the test coverage we automatically generate extra test cases.
+The follwing test case,
+
+```yaml
+tests:
+  - name: "Compare"
+    query: |
+      ~str~ < "z"
+    variables:
+      str: ["a", "b"]
+```
+
+will generate the following additional test queries:
+
+- Plain: `"a" < "z"`
+- GenFilter: `*[_id == "foo"][bar < "z"][]._id` (and create the needed documents)
+- GenFetch: `*[_id == "foo"][0].bar < "z"` (and create the needed documents)
+
+The rules of how the tests are generated are as follows:
+
+- If a test case has an explicit dataset (either `documents` or `dataset`) then nothing will be generated.
+- Every variable which contains valid JSON is eligable for automatic test generation.
+- We assume that every variable is *standalone* (e.g. we can safely pull them out).
+  You can use `standloneVariables: ["var1"]` in case there are some variables which are not standalone.
+- Set `genFilter: false` or `genFetch: false` to disable the generated tests.
+  
 
 ### Specifying datasets
 

--- a/test/expr/slice.yml
+++ b/test/expr/slice.yml
@@ -1,16 +1,13 @@
 name: Slice
-documents:
-  - _id: "array-empty"
-    _type: "data"
-    value: []
-  - _id: "array-full"
-    _type: "data"
-    value: ["string", 1, 3.14, true, null, [1], {"key": "value"}]
+
+variables:
+  full: '["string", 1, 3.14, true, null, [1], {"key": "value"}]'
 
 tests:
   - name: "Item slicing"
     query: |
-      *[_id == "array-full"][0].value[~slice~]
+      ~full~[~slice~]
+    standaloneVariables: ['full']
     tests:
       - {variables: {slice: 0}, result: "string"}
       - {variables: {slice: 1}, result: 1}
@@ -44,7 +41,7 @@ tests:
 
   - name: "Range slicing"
     query: |
-      *[_id == "array-full"][0].value[~slice~]
+      ~full~[~slice~]
     tests:
       - {variables: {slice: "0..0"}, result: ["string"]}
       - {variables: {slice: "0..1"}, result: ["string", 1]}
@@ -61,7 +58,7 @@ tests:
 
   - name: "Exclusive range slicing"
     query: |
-      *[_id == "array-full"][0].value[~slice~]
+      ~full~[~slice~]
     tests:
       - {variables: {slice: "0...1"}, result: ["string"]}
       - {variables: {slice: "0...2"}, result: ["string", 1]}

--- a/test/operator/and.yml
+++ b/test/operator/and.yml
@@ -1,29 +1,12 @@
 name: "And operator"
-documents:
-- _id: "id"
-  _type: "test"
-  v_true: true
-  v_false: false
-  v_string: "string"
-  v_integer: 1
 
 tests:
 - variables:
-    T:
-    - "*[_id=='id'][0].v_true"
-    - "true"
-    F:
-    - "*[_id=='id'][0].v_false"
-    - "false"
-    N:
-    - "*[_id=='id'][0].v_null"
-    - "null"
-    S:
-    - "*[_id=='id'][0].v_string"
-    - "'abc'"
-    I:
-    - "*[_id=='id'][0].v_integer"
-    - "123"
+    T: "true"
+    F: "false"
+    N: "null"
+    S: '"abc"'
+    I: "123"
   tests:
 
   # Basic true/false

--- a/test/operator/comparison.yml
+++ b/test/operator/comparison.yml
@@ -41,20 +41,27 @@ tests:
 
 - name: "Boolean"
   result: true
+  variables:
+    true: "true"
+    false: "false"
   tests:
-  - query: 'true ~gt~ false'
-  - query: 'false ~lt~ true'
-  - query: 'true ~eq~ true'
-  - query: 'false ~eq~ false'
+  - query: '~true~ ~gt~ ~false~'
+  - query: '~false~ ~lt~ ~true~'
+  - query: '~true~ ~eq~ ~true~'
+  - query: '~false~ ~eq~ ~false~'
 
 - name: "Strings"
   result: true
+  variables:
+    a: '"a"'
+    b: '"b"'
+    ab: '"ab"'
   tests:
-  - query: '"a" ~eq~ "a"'
-  - query: '"a" ~lt~ "b"'
-  - query: '"a" ~lt~ "ab"'
-  - query: '"b" ~gt~ "a"'
-  - query: '"ab" ~gt~ "a"'
+  - query: '~a~ ~eq~ ~a~'
+  - query: '~a~ ~lt~ ~b~'
+  - query: '~a~ ~lt~ ~ab~'
+  - query: '~b~ ~gt~ ~a~'
+  - query: '~ab~ ~gt~ ~a~'
 
 - name: "Datetimes"
   result: true

--- a/test/operator/comparison.yml
+++ b/test/operator/comparison.yml
@@ -65,11 +65,25 @@ tests:
 
 - name: "Datetimes"
   result: true
+  variables:
+    a: '"2020-01-01T12:00:00Z"'
+    a2: '"2020-01-01T13:00:00+01:00"'
+    b: '"2020-01-01T12:00:00.001Z"'
+    c: '"2020-01-01T13:00:00Z"'
   tests:
-  - query: 'dateTime("2020-01-01T12:00:00Z") ~eq~ dateTime("2020-01-01T12:00:00Z")'
-  - query: 'dateTime("2020-01-01T13:00:00+01:00") ~eq~ dateTime("2020-01-01T12:00:00Z")'
-  - query: 'dateTime("2020-01-01T12:00:00Z") ~lt~ dateTime("2020-01-01T13:00:00Z")'
-  - query: 'dateTime("2020-01-01T12:00:00.001Z") ~gt~ dateTime("2020-01-01T12:00:00Z")'
+  - query: 'dateTime(~a~) ~eq~ dateTime(~a~)'
+  - query: 'dateTime(~a2~) ~eq~ dateTime(~a~)'
+  - query: 'dateTime(~a~) ~lt~ dateTime(~c~)'
+  - query: 'dateTime(~b~) ~gt~ dateTime(~a~)'
+
+- name: "Datetimes against strings"
+  result: null
+  variables:
+    a: '"2020-01-01T12:00:00Z"'
+    b: '"2020-01-01T13:00:00Z"'
+  tests:
+  - query: 'dateTime(~a~) ~lt~ ~b~'
+  - query: '~a~ ~lt~ dateTime(~b~)'
 
 - name: "Mixed types"
   result: null

--- a/test/operator/match.yml
+++ b/test/operator/match.yml
@@ -1,72 +1,44 @@
 name: "Match operator"
-documents:
-- _id: "doc"
-  _type: "doc"
-  text: "hello world FOO-bar"
-  pattern1: "hel*"
-  pattern2: "fo"
-  patterns: ["hello", "foo"]
 
 variables:
-  text:
-  - '"hello world FOO-bar"'
-  - '*[_id=="doc"][0].text'
+  text: '"hello world FOO-bar"'
+  pattern1: '"hel*"'
+  pattern2: '"fo"'
+  patterns: '["hello", "foo"]'
 
 tests:
-- result: true
+- query: |
+    ~text~ match ~pattern~
+
   tests:
     - name: "Matching"
       result: true
-      tests:
-      - query: |
-          ~text~ match "hello"
-      - query: |
-          ~text~ match "hello*"
-      - query: |
-          ~text~ match "hel*"
-      - query: |
-          ~text~ match "foo"
-      - query: |
-          ~text~ match "bar"
-      - query: |
-          ~text~ match "*ld"
-      - query: |
-          ~text~ match "h*l*o"
-      - query: |
-          ~text~ match "foo-bar"
-      - query: |
-          ~text~ match "hello bar"
-      - query: |
-          ~text~ match "hel* bar"
-      - query: |
-          ~text~ match ["hel*", "bar"]
+      variables:
+        pattern:
+        - '"hello*"'
+        - '"hel*"'
+        - '"foo"'
+        - '"bar"'
+        - '"*ld"'
+        - '"h*l*o"'
+        - '"foo-bar"'
+        - '"hel* bar"'
+        - '["hel*", "bar"]'
+        - '["hello", "foo"]'
 
     - name: "Non-matching"
       result: false
-      tests:
-      - query: |
-          ~text~ match "hell"
-      - query: |
-          ~text~ match "fo bar"
-
-- name: "Dynamic pattern true"
-  query: |
-    ~text~ match *[_id=="doc"][0].pattern1
-  result: true
-
-- name: "Dynamic pattern false"
-  query: |
-    ~text~ match *[_id=="doc"][0].pattern2
-  result: false
-
-- name: "Dynamic pattern array"
-  query: |
-    ~text~ match *[_id=="doc"][0].patterns
-  result: true
+      variables:
+        pattern:
+        - '"fo"'
+        - '"hell"'
+        - '"fo bar"'
 
 - name: "Multiple text"
+  variables:
+    abc: '"abc"'
   query: |
-    ~text~ match "abc"
+    ~text~ match ~abc~
   tests:
   - {variables: {text: '["abc"]'}, result: true}
   - {variables: {text: '["abc", "def"]'}, result: true}

--- a/test/operator/or.yml
+++ b/test/operator/or.yml
@@ -1,29 +1,12 @@
 name: "Or operator"
-documents:
-- _id: "id"
-  _type: "test"
-  v_true: true
-  v_false: false
-  v_string: "string"
-  v_integer: 1
 
 tests:
 - variables:
-    T:
-    - "*[_id=='id'][0].v_true"
-    - "true"
-    F:
-    - "*[_id=='id'][0].v_false"
-    - "false"
-    N:
-    - "*[_id=='id'][0].v_null"
-    - "null"
-    S:
-    - "*[_id=='id'][0].v_string"
-    - "'abc'"
-    I:
-    - "*[_id=='id'][0].v_integer"
-    - "123"
+    T: "true"
+    F: "false"
+    N: "null"
+    S: '"abc"'
+    I: 123
   tests:
 
   # Basic true/false

--- a/test/type/range.yml
+++ b/test/type/range.yml
@@ -27,6 +27,7 @@ tests:
     t:
     - "[]"
     - "{}"
+  genFilter: false
   result: null
   tests:
   - query: "~t~ .. ~t~"
@@ -34,6 +35,7 @@ tests:
 
 - name: "Mixed type"
   result: null
+  genFilter: false
   tests:
   - query: '1 .. "a"'
   - query: '"a" .. 1'


### PR DESCRIPTION
Before:

```
## Before
$ wc -l suite.json
1773

## After
$ wc -l suite.json
4273
```

See the text in the README:

> To increase the test coverage we automatically generate extra test cases.
> The follwing test case,
> ```yaml
> tests:
>   - name: "Compare"
>     query: |
>       ~str~ < "z"
>     variables:
>       str: ["a", "b"]
> ```
> will generate the following additional test queries:
> - Plain: `"a" < "z"`
> - GenFilter: `*[_id == "foo"][bar < "z"][]._id` (and create the needed documents)
> - GenFetch: `*[_id == "foo"][0].bar < "z"` (and create the needed documents)
> 
> The rules of how the tests are generated are as follows:
> - If a test case has an explicit dataset (either `documents` or `dataset`) then nothing will be generated.
> - Every variable which contains valid JSON is eligable for automatic test generation.
> - We assume that every variable is *standalone* (e.g. we can safely pull them out). You can use `standloneVariables: ["var1"]` in case there are some variables which are not standalone.
> - Set `genFilter: false` or `genFetch: false` to disable the generated tests.

As you can see in the updated test files I was able to remove some explicit test cases since they are now covered by automatic generation.
