### PR TITLE
Generate queries to test joins

### DIFF
--- a/test/type/range.yml
+++ b/test/type/range.yml
@@ -28,6 +28,7 @@ tests:
     - "[]"
     - "{}"
   genFilter: false
+  genJoin: false
   result: null
   tests:
   - query: "~t~ .. ~t~"


### PR DESCRIPTION
This will automatically generate queries on the form:

```
*[_id == "doc1"]{"children": *[_id == "doc2"][^.f1 == f2][]._id}
```

Before: 4341 tests.
After: 4732 tests