### PR TITLE
Disable genFilter for path() test

### DIFF
--- a/test/operator/in.yml
+++ b/test/operator/in.yml
@@ -112,6 +112,7 @@ tests:
 - name: "Path"
   query: |
     ~el~ in path(~path~)
+  genFilter: false
   tests:
 
   - result: true


### PR DESCRIPTION
`$attr in path()` is only valid when attr is _id, thus making it impossible to use any genFilter test.