### PR TITLE
Feature support + score() and boost() tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,37 @@ A test can specify a list of named features that it requires, which a test runne
 - `namespaces`: Namespace support for functions.
 - `scoring`: Support for scoring with `score()` and `boost()`.
 
+### Scores
+
+Since the scoring algorithm used by `score()` is currently implementation-defined, tests cannot contain the literal score. Instead, tests must use an ordinal number to represent the _position_ among the total list of result scores. The test runner, when comparing results, should replace the actual scores with this algorithm:
+
+* Take all encountered scores in the results
+* Remove duplicates
+* Sort them
+* Replace each score with an attribute `_pos` containing the position in the list
+
+For example: If a query returns:
+
+```yaml
+- {id: "a", _score: 1.0}
+- {id: "b", _score: 1.2}
+- {id: "c", _score: 1.2}
+- {id: "d", _score: 1.4}
+```
+
+then these should be remapped as:
+
+```yaml
+- {id: "a", _pos: 1}
+- {id: "b", _pos: 2}
+- {id: "c", _pos: 2}
+- {id: "d", _pos: 3}
+```
+
+…and this is what the test needs to test equality against.
+
+In other words, any value with equal score is given the same ordinal value.
+
 ### Specifying datasets
 
 Tests can either declare datasets inline (using the `documents` property) or refer to an external dataset by name:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ The rules of how the tests are generated are as follows:
   You can use `standloneVariables: ["var1"]` in case there are some variables which are not standalone.
 - Set `genFilter: false` or `genFetch: false` to disable the generated tests.
 
+### Features
+
+A test can specify a list of named features that it requires, which a test runner can use to skip tests or enable specific modes. Currently defined features:
+
+- `experimentalFunctions`: Experimental functions that are not part of the GROQ spec.
+- `namespaces`: Namespace support for functions.
+- `scoring`: Support for scoring with `score()` and `boost()`.
 
 ### Specifying datasets
 

--- a/src/build.js
+++ b/src/build.js
@@ -227,7 +227,7 @@ class Builder {
       _type: 'reference',
     }
     let valid = test.valid != null ? test.valid : true
-    let experimental = test.experimental || false
+    let features = test.features || []
 
     let entry = {
       _id,
@@ -237,7 +237,7 @@ class Builder {
       query: test.query,
       result: valid ? test.result : null,
       valid,
-      experimental,
+      features,
       ...extra,
     }
 

--- a/test/function/boost.yml
+++ b/test/function/boost.yml
@@ -1,0 +1,80 @@
+# See readme for how to test equality on scores.
+
+name: "boost() function"
+
+features:
+- scoring
+
+documents:
+- _id: "a"
+  _type: "doc"
+  value: 1
+  text: "hello"
+- _id: "b"
+  _type: "doc"
+  value: 2
+  text: "Hello world"
+- _id: "c"
+  _type: "doc"
+  value: 3
+  text: "Thanks for all the fish"
+- _id: "d"
+  _type: "doc"
+  value: 4
+  text: "Fish, fish, just fish"
+
+tests:
+- name: Illegal use outside score()
+  query: ~expr~
+  valid: false
+  variables:
+    expr:
+    - boost(*, 10)
+    - boost(a)
+    - "boost({'a': 42}, 10)"
+    - "{'a': boost({'a': 42}, 3)}"
+
+- name: Equality
+  features:
+  - scoring
+  query: |
+    ~expr~
+      | score(boost(value == 3, 2), value == 4)
+      | order(_score desc, _id) {_id, _score}
+  variables:
+    expr:
+    - "*"
+    - "*[0..-1]"
+    - "*[_type == 'doc']"
+  result:
+  - _id: c
+    _pos: 1
+  - _id: d
+    _pos: 2
+  - _id: a
+    _pos: 3
+  - _id: b
+    _pos: 3
+
+- name: Text match
+  features:
+  - scoring
+  query: |
+    ~expr~
+      | score(boost(text match "world", 10), text match "fish")
+      | order(_score desc, _id) {_id, _score}
+  variables:
+    expr:
+    - "*"
+    - "*[0..-1]"
+    - "*[_type == 'doc']"
+  result:
+  - _id: b
+    _pos: 1
+  - _id: d
+    _pos: 2
+  - _id: c
+    _pos: 3
+  - _id: a
+    _pos: 4
+

--- a/test/function/coalesce.yml
+++ b/test/function/coalesce.yml
@@ -2,7 +2,8 @@ name: "coalesce() function"
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::coalesce()
   result: null

--- a/test/function/count.yml
+++ b/test/function/count.yml
@@ -28,7 +28,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::count(*[_type == "doc"])
   result: 2

--- a/test/function/dateTime.yml
+++ b/test/function/dateTime.yml
@@ -2,7 +2,8 @@ name: "dateTime() function"
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::dateTime("2002-10-02T12:34:56Z")
   result: "2002-10-02T12:34:56Z"

--- a/test/function/defined.yml
+++ b/test/function/defined.yml
@@ -8,7 +8,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::defined(null)
   result: false

--- a/test/function/experimental/avg.yml
+++ b/test/function/experimental/avg.yml
@@ -1,5 +1,6 @@
 name: "avg() function"
-experimental: true
+features:
+- experimentalFunctions
 
 documents:
 - _id: "a"

--- a/test/function/experimental/distinct.yml
+++ b/test/function/experimental/distinct.yml
@@ -1,5 +1,6 @@
 name: "distinct() function"
-experimental: true
+features:
+- experimentalFunctions
 
 documents:
 - _id: "a"

--- a/test/function/experimental/max.yml
+++ b/test/function/experimental/max.yml
@@ -1,5 +1,6 @@
 name: "max() function"
-experimental: true
+features:
+- experimentalFunctions
 
 documents:
 - _id: "a"

--- a/test/function/experimental/min.yml
+++ b/test/function/experimental/min.yml
@@ -1,5 +1,6 @@
 name: "min() function"
-experimental: true
+features:
+- experimentalFunctions
 
 documents:
 - _id: "a"

--- a/test/function/experimental/sum.yml
+++ b/test/function/experimental/sum.yml
@@ -1,5 +1,6 @@
 name: "sum() function"
-experimental: true
+features:
+- experimentalFunctions
 
 documents:
 - _id: "a"

--- a/test/function/identity.yml
+++ b/test/function/identity.yml
@@ -3,7 +3,8 @@ result: true
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     defined(global::identity())
 

--- a/test/function/length.yml
+++ b/test/function/length.yml
@@ -11,7 +11,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::length([1])
   result: 1

--- a/test/function/order.yml
+++ b/test/function/order.yml
@@ -102,7 +102,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     *[_type=="order-boolean"]|global::order(value asc)[].value
   result: [false, true]

--- a/test/function/references.yml
+++ b/test/function/references.yml
@@ -76,7 +76,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     *[global::references("b")]{name}
   result:

--- a/test/function/round.yml
+++ b/test/function/round.yml
@@ -2,7 +2,8 @@ name: "round() function"
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::round(3.14)
   result: 3

--- a/test/function/score.yml
+++ b/test/function/score.yml
@@ -1,0 +1,122 @@
+# See readme for how to test equality on scores.
+
+name: "score() function"
+
+features:
+- scoring
+
+documents:
+- _id: "a"
+  _type: "doc"
+  value: 1
+  text: "hello"
+- _id: "b"
+  _type: "doc"
+  value: 2
+  text: "Hello world"
+- _id: "c"
+  _type: "doc"
+  value: 3
+  text: "Thanks for all the fish"
+- _id: "d"
+  _type: "doc"
+  value: 4
+  text: "Fish, fish, just fish"
+
+tests:
+- name: Illegal use
+  query: ~expr~
+  valid: false
+  variables:
+    expr:
+    - "*{foo} | score(a == 1)"
+    - "*[0] | score(a == 1)"
+    - "score(a == 1)"
+
+- name: Equality
+  features:
+  - scoring
+  query: |
+    ~expr~
+      | score(value == 1)
+      | order(_score desc, _id) {_id, _score}
+  variables:
+    expr:
+    - "*"
+    - "*[0..-1]"
+    - "*[_type == 'doc']"
+  result:
+  - _id: a
+    _pos: 1
+  - _id: b
+    _pos: 2
+  - _id: c
+    _pos: 2
+  - _id: d
+    _pos: 2
+
+- name: Inequality
+  features:
+  - scoring
+  query: |
+    ~expr~
+      | score(value != 1)
+      | order(_score desc, _id) {_id, _score}
+  variables:
+    expr:
+    - "*"
+    - "*[0..-1]"
+    - "*[_type == 'doc']"
+  result:
+  - _id: b
+    _pos: 1
+  - _id: c
+    _pos: 1
+  - _id: d
+    _pos: 1
+  - _id: a
+    _pos: 2
+
+- name: Text match
+  features:
+  - scoring
+  query: |
+    ~expr~
+      | score(text match "fish")
+      | order(_score desc, _id) {_id, _score}
+  variables:
+    expr:
+    - "*"
+    - "*[0..-1]"
+    - "*[_type == 'doc']"
+  result:
+  - _id: d
+    _pos: 1
+  - _id: c
+    _pos: 2
+  - _id: a
+    _pos: 3
+  - _id: b
+    _pos: 3
+
+- name: Negated text match
+  features:
+  - scoring
+  query: |
+    ~expr~
+      | score(!(text match "fish"))
+      | order(_score desc, _id) {_id, _score}
+  variables:
+    expr:
+    - "*"
+    - "*[0..-1]"
+    - "*[_type == 'doc']"
+  result:
+  - _id: a
+    _pos: 1
+  - _id: b
+    _pos: 1
+  - _id: c
+    _pos: 2
+  - _id: d
+    _pos: 2

--- a/test/function/select.yml
+++ b/test/function/select.yml
@@ -12,7 +12,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::select("a", "b")
   result: null

--- a/test/function/string.yml
+++ b/test/function/string.yml
@@ -19,7 +19,8 @@ documents:
 
 tests:
 - name: "With namespace"
-  experimental: true
+  features:
+  - namespaces
   query: |
     global::string(true)
   result: "true"


### PR DESCRIPTION
Replaces `experimental` setting with general-purpose `features` list. This introduces two features for existing tests: `experimentalFunctions` and `namespaces`.

Add tests for `score()` and `boost()`, which use the feature flag `scoring`. To run, this requires test runner special sauce. These tests aren't exactly complete, but I'd rather write a few tests for this new feature flag, and get feedback first on the implementation, then add more extensive tests later.
