### PR TITLE
feat: add tests for 'diff' extension functions

### DIFF
--- a/test/extensions/diff/changedAny.yml
+++ b/test/extensions/diff/changedAny.yml
@@ -1,0 +1,48 @@
+name: "diff:changedAny() function"
+version: '>=2.0.0'
+
+features
+- namespaces
+- diff
+
+documents:
+- _id: "original"
+  _type: "document"
+  a: 1
+  b: 2
+  this:
+    foo: "3"
+    bar: "4"
+  that:
+    foo: "5"
+    bar: "6"
+
+- _id: "changed"
+  _type: "document"
+  a: 100
+  b: 2
+  this:
+    foo: "300"
+    bar: "4"
+  that:
+    foo: "500"
+    bar: "6"
+
+tests:
+- name: "When any selected attributes have changed"
+  query: |
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed'][0], ~selector~)
+  variables:
+    selector:
+      - 'a'
+      - '(a, b)'
+      - 'this.foo'
+      - 'this.(foo, bar)'
+      - '(this, that).foo'
+  result: true
+
+tests:
+- name: "When no selected attributes have changed"
+  query: |
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], (a, b))
+  result: false

--- a/test/extensions/diff/changedAny.yml
+++ b/test/extensions/diff/changedAny.yml
@@ -10,10 +10,10 @@ documents:
   _type: "document"
   a: 1
   b: 2
-  this:
+  alpha:
     foo: "3"
     bar: "4"
-  that:
+  beta:
     foo: "5"
     bar: "6"
 
@@ -21,10 +21,10 @@ documents:
   _type: "document"
   a: 100
   b: 2
-  this:
+  alpha:
     foo: "300"
     bar: "4"
-  that:
+  beta:
     foo: "500"
     bar: "6"
 
@@ -36,9 +36,9 @@ tests:
     selector:
       - 'a'
       - '(a, b)'
-      - 'this.foo'
-      - 'this.(foo, bar)'
-      - '(this, that).foo'
+      - 'alpha.foo'
+      - 'alpha.(foo, bar)'
+      - '(alpha, beta).foo'
   result: true
 
 tests:

--- a/test/extensions/diff/changedAny.yml
+++ b/test/extensions/diff/changedAny.yml
@@ -1,48 +1,47 @@
-name: "diff:changedAny() function"
+name: 'diff:changedAny() function'
 version: '>=2.0.0'
 
-features
-- namespaces
-- diff
+features:
+  - namespaces
+  - diff
 
 documents:
-- _id: "original"
-  _type: "document"
-  a: 1
-  b: 2
-  alpha:
-    foo: "3"
-    bar: "4"
-  beta:
-    foo: "5"
-    bar: "6"
+  - _id: 'original'
+    _type: 'document'
+    a: 1
+    b: 2
+    alpha:
+      foo: '3'
+      bar: '4'
+    beta:
+      foo: '5'
+      bar: '6'
 
-- _id: "changed"
-  _type: "document"
-  a: 100
-  b: 2
-  alpha:
-    foo: "300"
-    bar: "4"
-  beta:
-    foo: "500"
-    bar: "6"
-
-tests:
-- name: "When any selected attributes have changed"
-  query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed'][0], ~selector~)
-  variables:
-    selector:
-      - 'a'
-      - '(a, b)'
-      - 'alpha.foo'
-      - 'alpha.(foo, bar)'
-      - '(alpha, beta).foo'
-  result: true
+  - _id: 'changed'
+    _type: 'document'
+    a: 100
+    b: 2
+    alpha:
+      foo: '300'
+      bar: '4'
+    beta:
+      foo: '500'
+      bar: '6'
 
 tests:
-- name: "When no selected attributes have changed"
-  query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], (a, b))
-  result: false
+  - name: 'When any selected attributes have changed'
+    query: |
+      diff:changedAny(*[_id == 'original'][0], *[_id == 'changed'][0], ~selector~)
+    variables:
+      selector:
+        - 'a'
+        - '(a, b)'
+        - 'alpha.foo'
+        - 'alpha.(foo, bar)'
+        - '(alpha, beta).foo'
+    result: true
+
+  - name: 'When no selected attributes have changed'
+    query: |
+      diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], (a, b))
+    result: false

--- a/test/extensions/diff/changedOnly.yml
+++ b/test/extensions/diff/changedOnly.yml
@@ -1,0 +1,64 @@
+name: "diff:changedOnly() function"
+version: '>=2.0.0'
+
+features
+- namespaces
+- diff
+
+documents:
+- _id: "original"
+  _type: "document"
+  a: 1
+  b: 2
+  this:
+    foo: "3"
+    bar: "4"
+  that:
+    foo: "5"
+    bar: "6"
+
+- _id: "changed_1"
+  _type: "document"
+  a: 1
+  b: 2
+  this:
+    foo: "300"
+    bar: "4"
+  that:
+    foo: "5"
+    bar: "6"
+
+- _id: "changed_2"
+  _type: "document"
+  a: 1
+  b: 2
+  this:
+    foo: "300"
+    bar: "4"
+  that:
+    foo: "500"
+    bar: "6"
+
+tests:
+- name: "When only the selected attributes change"
+  query: |
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_1'][0], this.foo)
+  variables:
+    selector:
+      - 'a'
+      - '(a, b)'
+      - 'this.(foo, bar)'
+      - '(this, that).foo'
+  result: true
+
+tests:
+- name: "When no attributes have changed"
+  query: |
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], this.foo)
+  result: false
+
+tests:
+- name: "When both selected and non-selected attributes change"
+  query: |
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_2'][0], this.foo)
+  result: false

--- a/test/extensions/diff/changedOnly.yml
+++ b/test/extensions/diff/changedOnly.yml
@@ -1,65 +1,63 @@
-name: "diff:changedOnly() function"
+name: 'diff:changedOnly() function'
 version: '>=2.0.0'
 
-features
-- namespaces
-- diff
+features:
+  - namespaces
+  - diff
 
 documents:
-- _id: "original"
-  _type: "document"
-  a: 1
-  b: 2
-  alpha:
-    foo: "3"
-    bar: "4"
-  beta:
-    foo: "5"
-    bar: "6"
+  - _id: 'original'
+    _type: 'document'
+    a: 1
+    b: 2
+    alpha:
+      foo: '3'
+      bar: '4'
+    beta:
+      foo: '5'
+      bar: '6'
 
-- _id: "changed_1"
-  _type: "document"
-  a: 1
-  b: 2
-  alpha:
-    foo: "300"
-    bar: "4"
-  beta:
-    foo: "5"
-    bar: "6"
+  - _id: 'changed_1'
+    _type: 'document'
+    a: 1
+    b: 2
+    alpha:
+      foo: '300'
+      bar: '4'
+    beta:
+      foo: '5'
+      bar: '6'
 
-- _id: "changed_2"
-  _type: "document"
-  a: 1
-  b: 2
-  alpha:
-    foo: "300"
-    bar: "4"
-  beta:
-    foo: "500"
-    bar: "6"
-
-tests:
-- name: "When only the selected attributes change"
-  query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_1'][0], ~selector~)
-  variables:
-    selector:
-      - 'a'
-      - '(a, b)'
-      - 'alpha.foo'
-      - 'alpha.(foo, bar)'
-      - '(alpha, beta).foo'
-  result: true
+  - _id: 'changed_2'
+    _type: 'document'
+    a: 1
+    b: 2
+    alpha:
+      foo: '300'
+      bar: '4'
+    beta:
+      foo: '500'
+      bar: '6'
 
 tests:
-- name: "When no attributes have changed"
-  query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], alpha.foo)
-  result: false
+  - name: 'When only the selected attributes change'
+    query: |
+      diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_1'][0], ~selector~)
+    variables:
+      selector:
+        - 'a'
+        - '(a, b)'
+        - 'alpha.foo'
+        - 'alpha.(foo, bar)'
+        - '(alpha, beta).foo'
+    result: true
 
-tests:
-- name: "When both selected and non-selected attributes change"
-  query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_2'][0], alpha.foo)
-  result: false
+  - name: 'When no attributes have changed'
+    query: |
+      diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], alpha.foo)
+    result: false
+
+  - name: 'When both selected and non-selected attributes change'
+    query: |
+      diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_2'][0], alpha.foo)
+    result: false

--- a/test/extensions/diff/changedOnly.yml
+++ b/test/extensions/diff/changedOnly.yml
@@ -10,10 +10,10 @@ documents:
   _type: "document"
   a: 1
   b: 2
-  this:
+  alpha:
     foo: "3"
     bar: "4"
-  that:
+  beta:
     foo: "5"
     bar: "6"
 
@@ -21,10 +21,10 @@ documents:
   _type: "document"
   a: 1
   b: 2
-  this:
+  alpha:
     foo: "300"
     bar: "4"
-  that:
+  beta:
     foo: "5"
     bar: "6"
 
@@ -32,33 +32,34 @@ documents:
   _type: "document"
   a: 1
   b: 2
-  this:
+  alpha:
     foo: "300"
     bar: "4"
-  that:
+  beta:
     foo: "500"
     bar: "6"
 
 tests:
 - name: "When only the selected attributes change"
   query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_1'][0], this.foo)
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_1'][0], ~selector~)
   variables:
     selector:
       - 'a'
       - '(a, b)'
-      - 'this.(foo, bar)'
-      - '(this, that).foo'
+      - 'alpha.foo'
+      - 'alpha.(foo, bar)'
+      - '(alpha, beta).foo'
   result: true
 
 tests:
 - name: "When no attributes have changed"
   query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], this.foo)
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'original'][0], alpha.foo)
   result: false
 
 tests:
 - name: "When both selected and non-selected attributes change"
   query: |
-    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_2'][0], this.foo)
+    diff:changedAny(*[_id == 'original'][0], *[_id == 'changed_2'][0], alpha.foo)
   result: false


### PR DESCRIPTION
We are adding the `diff` extension to GROQ, this PR adds tests for the current feature set `diff` implements.

[The `diff` extension in the GROQ spec.](https://sanity-io.github.io/GROQ/draft/#sec-Diff-Extension)

I'm not sure if all implementations contain the `diff` functionality, so once approved I'll wait to merge this until I've confirmed it's OK to do so. I know at least `groq-js` still needs the implementation.

# Changes
* Add tests for `diff::changedAny()` and `diff::ChangedOnly()`
