### PR TITLE
Remove invalid selector test

### DIFF
--- a/test/function/diff.yml
+++ b/test/function/diff.yml
@@ -54,6 +54,12 @@ tests:
   valid: false
   query: |
     diff::changedAny({}, {}, ~selector~)
+
+  # Since we test for literal numbers in the variables we need to disable automatic test generation.
+  genFilter: false
+  genFetch: false
+  genJoin: false
+
   variables:
     selector:
     - "foo + 1"


### PR DESCRIPTION
The automatic test generator created a test for `diff::changedAny({}, {}, f_2)` since it finds a valid JSON value in the variables list. That was not the intention here.