### PR TITLE
Autogenerate negation tests

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -370,13 +370,29 @@ class Builder {
           let genAlt = alt.slice()
           genAlt[i] = genDoc.fieldId
           let filter = replaceVariables(query, genAlt)
-          let fullQuery = `${fetchDocQuery}[${filter}][]._id`
-          let expected = result === true ? [genDoc.docId] : []
 
-          yield {
-            query: fullQuery,
-            result: expected,
-            dataset: this.generatedDataset.ref(),
+          {
+            // Regular query
+            let fullQuery = `${fetchDocQuery}[${filter}][]._id`
+            let expected = result === true ? [genDoc.docId] : []
+
+            yield {
+              query: fullQuery,
+              result: expected,
+              dataset: this.generatedDataset.ref(),
+            }
+          }
+
+          {
+            // Negated query
+            let fullQuery = `${fetchDocQuery}[!(${filter})][]._id`
+            let expected = result === false ? [genDoc.docId] : []
+
+            yield {
+              query: fullQuery,
+              result: expected,
+              dataset: this.generatedDataset.ref(),
+            }
           }
         }
 


### PR DESCRIPTION
When we have a test query on the form `string::startsWith(~foo~, ~bar~)` this will now generate another test on the form `*[!(string::startsWith(foo, "abx")][]._id` (+ all combinations).