### PR TITLE
feat: autogenerate more startsWith tests

### DIFF
--- a/test/function/string-startsWith.yml
+++ b/test/function/string-startsWith.yml
@@ -9,18 +9,18 @@ tests:
   tests:
   - name: Empty prefix
     variables:
-      str: "'a'"
-      prefix: "''"
+      str: '"a"'
+      prefix: '""'
     result: true
   - name: Single character prefix
     variables:
-      str: "'abc'"
-      prefix: "'a'"
+      str: '"abc"'
+      prefix: '"a"'
     result: true
   - name: Common prefix, but not fully
     variables:
-      str: "'abc'"
-      prefix: "'abx'"
+      str: '"abc"'
+      prefix: '"abx"'
     result: false
 
 - name: "Non-string types"


### PR DESCRIPTION
The variable has to be JSON for the autogenerator to work.

We might want to consider making the autogenerator a bit more explicit as this is a bit of a gotcha.