### PR TITLE
test: add number + datetime commutative case

### DIFF
--- a/test/operator/plus.yml
+++ b/test/operator/plus.yml
@@ -45,3 +45,20 @@ tests:
       left: '"2020-01-01T11:59:59.500Z"'
       right: '0.5'
     result: "2020-01-01T12:00:00Z"
+
+- name: "number + datetime"
+  query: |
+    ~left~ + dateTime(~right~)
+  tests:
+  - variables:
+      left: '3600'
+      right: '"2020-01-01T11:00:00Z"'
+    result: "2020-01-01T12:00:00Z"
+  - variables:
+      left: '5'
+      right: '"2020-01-01T11:59:55Z"'
+    result: "2020-01-01T12:00:00Z"
+  - variables:
+      left: '0.5'
+      right: '"2020-01-01T11:59:59.500Z"'
+    result: "2020-01-01T12:00:00Z"


### PR DESCRIPTION
### Description

This PR adds a test for the `number + dateTime` in addition to the `dateTime + number` that we already had in the suite, to ensure it's implemented as a commutative operation. Gradient and `groq-js` already has this, and it's also documented in the latest version of the spec.